### PR TITLE
Adds support for Blender 4.0.0

### DIFF
--- a/pdx_blender/blender_import_export.py
+++ b/pdx_blender/blender_import_export.py
@@ -703,7 +703,14 @@ def create_shader(PDX_material, shader_name, texture_dir, template_only=False):
 
         links.new(material_texture.outputs["Color"], separate_rgb.inputs["Image"])
         # links.new(separate_rgb.outputs['R'], shader_root.inputs['Specular'])  # material.R used for custom mask?
-        links.new(separate_rgb.outputs["G"], shader_root.inputs["Specular"])
+ 
+        if bpy.app.version < (4, 0, 0):
+            # Fallback for older versions of Blender
+            links.new(separate_rgb.outputs["G"], shader_root.inputs["Specular"])
+        else: 
+            # 4.0.0 changed the Specular key to the following:
+            links.new(separate_rgb.outputs["G"], shader_root.inputs["Specular IOR Level"])
+        
         links.new(separate_rgb.outputs["B"], shader_root.inputs["Metallic"])
         links.new(material_texture.outputs["Alpha"], shader_root.inputs["Roughness"])
 


### PR DESCRIPTION
Blender 4.0.0 has changed the structure of the principled BSDF node such that we have more direct control over the Specular functions. This requires calls to the original Specular node to be renamed to fit the new pattern.

This pull request includes fallback for older versions of Blender to maintain compatibility. Tested on 3.6.4 and 4.0.0 beta.

Note: If you load a 3.6.4 material into Blender 4.0 with an actively used Specular node, the conversion to the new node will add a Mix node for the diffuse color for Specular Tint. In the case for materials created via io_pdx_mesh import, this mix node is left blank and is unneeded for native import of meshes.